### PR TITLE
Throw error encoding code point > 255

### DIFF
--- a/base122.js
+++ b/base122.js
@@ -31,8 +31,18 @@ function encode(rawData) {
     , curBit = 0 // Points to current bit needed
     , curMask = 0b10000000
     , outData = []
-    , getByte = dataType == kString ? i => rawData.codePointAt(i) : i => rawData[i]
+    , getByte = i => rawData[i]
     ;
+
+    if (dataType == kString) {
+        getByte = (i) => {
+            let val = rawData.codePointAt(i);
+            if (val > 255) {
+                throw "Unexpected code point at position: " + i + ". Expected value [0,255]. Got: " + val;
+            }
+            return val;
+        }
+    }
 
     // Get seven bits of input data. Returns false if there is no input left.
     function get7() {

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -82,4 +82,10 @@ tester.addTest('realBase64Data', () => {
     testBase64EncodeDecode(testData.base64.imgBug);
 });
 
+tester.addTest('throws error encoding strings with code points > 255', () => {
+    assert.throws(() => {
+        base122.encode("美");
+    })
+});
+
 tester.run();


### PR DESCRIPTION
# Summary

Throw error encoding String with a code point > 255.

# Background & Motivation

Intended to prevent malformed encoding. This was encountered in https://github.com/kevinAlbs/Base122/issues/6#issuecomment-1757956304

`encode` expects a String argument to [meet the conditions of `btoa`](https://developer.mozilla.org/en-US/docs/Web/API/btoa#unicode_strings):
> strings in which the code point of each character occupies only one byte.

Javascript String uses UTF-16. Code points in the input string exceed what one byte can store:

Example:
```javascript
// Javascript represents string as sequence of UTF-16.
let originalString = "美";
console.log(`originalString.codePointAt(0)=${originalString.codePointAt(0)}`); // Prints: 
// Prints: originalString.codePointAt(0)=32654
```

At present, encoding a string with code points > 255 results in no error. The resulting encoded data may not decode back to the original:

```javacript
let originalString = "美";
let originalStringAsUtf8Hex = Buffer.from(originalString, "utf-8").toString("hex");
console.log("originalStringAsUtf8Hex : " + originalStringAsUtf8Hex);

let encoded = base122.encode(originalString);
let decoded = base122.decode(encoded);

let decodedStringAsUtf8Hex = Buffer.from(decoded, "utf-8").toString("hex");
console.log("decodedStringAsUtf8Hex  : " + decodedStringAsUtf8Hex);

// Prints:
// originalStringAsUtf8Hex : e7be8e
// decodedStringAsUtf8Hex  : 8e
```

