### PR TITLE
Fix encoding multiple `<img>` one one line

### DIFF
--- a/base122.js
+++ b/base122.js
@@ -131,7 +131,7 @@ function encodeFile(inpath, outpath, options, callback) {
 
     let rl = readline.createInterface({ input: inStream });
     rl.on('line', (line) => {
-        let regexp = /src=[\"\']data:(.*);base64,(.*?)[\"\']/ig;
+        let regexp = /src=[\"\']data:(.*?);base64,(.*?)[\"\']/ig;
         let bodyRegExp = /<\/body>/i;
         let results;
         let prevIndex = 0;


### PR DESCRIPTION
This PR resolves an issue related to HTML file encoding.

Running `node encodeFile.js --html --add-decoder input.html output.html` on this input:

```html
<!doctype html>
<html lang="en">
<head><meta charset="utf-8"></head>
<body>
    <img src='data:image/jpeg;base64,Qw==' /><img src='data:image/jpeg;base64,Qw==' />
</html>
```

Results in this output with malformed HTML:

```html
<!doctype html>
<html lang="en">
<head><meta charset="utf-8"></head>
<body>
    <img data-b122="!@" data-b122m="image/jpeg;base64,Qw==' /><img src='data:image/jpeg" />
</html>
```