### PR TITLE
Do not write previously written matched line

### DIFF
--- a/base122.js
+++ b/base122.js
@@ -151,7 +151,7 @@ function encodeFile(inpath, outpath, options, callback) {
             if ((results = bodyRegExp.exec(line)) != null) {
                 // </body> cannot be valid if it's before any data URI.
                 if (results.index >= prevIndex) {
-                    outStream.write(line.substring(0, results.index) + '<script>' + decoderScript
+                    outStream.write(line.substring(prevIndex, results.index) + '<script>' + decoderScript
                         + '</script>');
                     prevIndex = results.index;
                 }


### PR DESCRIPTION
This PR intends to resolve https://github.com/kevinAlbs/Base122/issues/11

Prior to this PR, running `node encodeFile.js --html --add-decoder input.html output.html` on this input:

```html
<!doctype html>
<html>
<body><img src='data:image/jpeg;base64,Qw==' /></body>
</html>
```

Results in this output with malformed HTML:

```html
<!doctype html>
<html>
<body><img data-b122="!@"<body><img src='data:image/jpeg;base64,Qw==' /><script>!function(){function e(e){function t(e){e<<=1,l|=e>>>i,i+=7,i>=8&&(c[o++]=l,i-=8,l=e<<7-i&255)}for(var a=e.dataset.b122,n=e.dataset.b122m||"image/jpeg",r=[0,10,13,34,38,92],c=new Uint8Array(1.75*a.length|0),o=0,l=0,i=0,f=0;f<a.length;f++){var b=a.charCodeAt(f);if(b>127){var d=b>>>8&7;7!=d&&t(r[d]),t(127&b)}else t(b)}e.src=URL.createObjectURL(new Blob([new Uint8Array(c,0,o)],{type:n}))}for(var t=document.querySelectorAll("[data-b122]"),a=0;a<t.length;a++)e(t[a])}();</script></body>
</html>
```
